### PR TITLE
fix(setup): don't probe the SDCP port right before the test command

### DIFF
--- a/intg-sonysdcp/setup.py
+++ b/intg-sonysdcp/setup.py
@@ -339,18 +339,20 @@ async def setup_projector(ip:str = ""):
     if ip == "":
         ip = config.Setup.get("ip")
 
-    #Check if sdcp port is open
-    if not port_check(ip, sdcp_port):
-        _LOG.error("Timeout while connecting to SDCP port " + str(sdcp_port) + " on " + ip)
-        _LOG.info("Please check if you entered the correct ip of the projector and if SDCP/PJTalk is active and running on port " + str(sdcp_port))
-        raise ConnectionRefusedError
-
-    #After ip has been discovered check if PJ talk community is correct
+    #Send a test command to check that the sdcp port is open and that the pj talk community is correct.
+    #The projector only serves one SDCP connection at a time and needs a moment to release it again. Probing the port with a
+    #separate throwaway connection beforehand makes the projector drop the connection of the test command that follows it,
+    #which returns an empty response. So only probe the port after the test command failed, to tell a closed port apart from
+    #a wrong pj talk community in the error message.
     try:
         projector.get_lamp_hours(ip)
     except Exception as e:
         _LOG.error(e)
-        _LOG.error("Test command failed. Please check if the entered PJ talk community \"" + config.Setup.get("pjtalk_community") + "\" is correct")
+        if not port_check(ip, sdcp_port):
+            _LOG.error("Timeout while connecting to SDCP port " + str(sdcp_port) + " on " + ip)
+            _LOG.info("Please check if you entered the correct ip of the projector and if SDCP/PJTalk is active and running on port " + str(sdcp_port))
+        else:
+            _LOG.error("Test command failed. Please check if the entered PJ talk community \"" + config.Setup.get("pjtalk_community") + "\" is correct")
         raise ConnectionRefusedError from e
 
 


### PR DESCRIPTION
The projector only serves one SDCP connection at a time and needs a moment to release it again. port_check() opens a separate throwaway TCP connection to the SDCP port and closes it immediately before the test command is sent, so the projector drops the connection of that test command and returns an empty response. pysdcp then indexes into the empty buffer and setup fails with "IndexError: index out of range" even though the projector is reachable and the pj talk community is correct.

This is timing dependent and gets more likely the higher the network latency is, so it mainly affects projectors that are not on the local network.

The port probe is redundant on the success path, since the test command that follows it already proves that the port is open, and both failure paths raise the same ConnectionRefusedError. So only probe the port after the test command failed, which keeps the distinction between a closed port and a wrong pj talk community in the error message while leaving a single connection on the success path.

Measured against a VPL-VW1000ES over a ~150ms link, 6 runs each:
  test command alone                          6/6 ok
  after port_check() with shutdown()          3/6 ok
  after port_check() without shutdown()       1/6 ok